### PR TITLE
Run code formatter and enable clippy some clippy warns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 keywords = ["lyrics", "cli", "rust"]
+categories = ["command-line-utilities"]
 readme = "README.md"
 authors = ["Ishan Joshi <noobscience@duck.com>"]
 description = "A simple CLI to get lyrics of a song from Genius using a public availed API"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,53 +1,54 @@
 use inquire::Text;
 
-pub fn get_input(msg: &str, help: Option<&str>, default: Option<&str>)->String{
-    let input = Text::new(msg)
-        .with_help_message(
-            help.unwrap_or(""),
-        )
-        .with_default(
-            default.unwrap_or(""),
-        )
-        .prompt();
-    let input = input.unwrap();
-    input
+pub fn get_input(msg: &str, help: Option<&str>, default: Option<&str>) -> String {
+    Text::new(msg)
+        .with_help_message(help.unwrap_or(""))
+        .with_default(default.unwrap_or(""))
+        .prompt()
+        .expect("Failed to get input")
 }
 
 pub fn parse_args() -> (String, String) {
     let args: Vec<String> = std::env::args().collect();
     let mut input = String::new();
     if args.len() > 1 {
-        for i in 1..args.len() {
-            input.push_str(&args[i]);
-            input.push_str(" ");
+        for arg in args.iter().skip(1) {
+            input.push_str(arg);
+            input.push(' ');
         }
         (input, args[1].clone())
-    }
-    else{
-        let output = get_input("Get any song's lyrics: ".into(), "Enter the song name: ".into(), "Never Gonna Give You Up".into());
+    } else {
+        let output = get_input(
+            "Get any song's lyrics: ",
+            "Enter the song name: ".into(),
+            "Never Gonna Give You Up".into(),
+        );
         (output, "lyrics".into())
     }
 }
 
-pub fn print_help(){
-    bunt::println!("Please provide a song name, no need to put {$underline}quotes{/$} around it ;)");
+pub fn print_help() {
+    bunt::println!(
+        "Please provide a song name, no need to put {$underline}quotes{/$} around it ;)"
+    );
     bunt::println!("{$blue}{$underline}Usage:{/$}{/$} ");
     bunt::println!("lyrics {$yellow}<Song Name>{/$}");
     bunt::println!("lyrics --help / -h");
     bunt::println!("lyrics --version / -v");
 }
 
-pub fn print_version(){
+pub fn print_version() {
     bunt::println!("lyrics {$yellow}v0.1.0{/$}");
 }
 
-pub fn splash_screen(){
-bunt::println!("{$green} _                _          {/$}");
-bunt::println!("{$red}| |              (_)         {/$}");
-bunt::println!("{$blue}| |    _   _ _ __ _  ___ ___ {/$}");
-bunt::println!("{$yellow}| |   | | | | '__| |/ __/ __|{/$}");
-bunt::println!("{$yellow}| |___| |_| | |  | | (__\\__ \\{/$}");
-bunt::println!("{$blue}\\_____/\\__, |_|  |_|\\___|___/{/$}");
-bunt::println!("{$red}        __/ |                {/$}");
-bunt::println!("{$green}       |___/                 {/$}Finder {$underline}v.0.1{/$}");
+#[allow(clippy::cognitive_complexity)]
+pub fn splash_screen() {
+    bunt::println!("{$green} _                _          {/$}");
+    bunt::println!("{$red}| |              (_)         {/$}");
+    bunt::println!("{$blue}| |    _   _ _ __ _  ___ ___ {/$}");
+    bunt::println!("{$yellow}| |   | | | | '__| |/ __/ __|{/$}");
+    bunt::println!("{$yellow}| |___| |_| | |  | | (__\\__ \\{/$}");
+    bunt::println!("{$blue}\\_____/\\__, |_|  |_|\\___|___/{/$}");
+    bunt::println!("{$red}        __/ |                {/$}");
+    bunt::println!("{$green}       |___/                 {/$}Finder {$underline}v.0.1{/$}");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+#![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
+#![allow(clippy::multiple_crate_versions)]
+
 use human_panic::setup_panic;
 
 mod cli;
@@ -10,16 +13,14 @@ async fn main() {
     let (input, cmd) = cli::parse_args();
     if cmd == "-h" || cmd == "--help" {
         cli::print_help();
-    }
-    else if cmd == "-v" || cmd == "--version" {
+    } else if cmd == "-v" || cmd == "--version" {
         cli::print_version();
-    }
-    else {
+    } else {
         let (url, lyrics) = web::get_lyrics(input.as_str()).await;
         bunt::println!("\n--------------------------");
         bunt::println!("{$yellow}{}{/$}", input);
         bunt::println!("--------------------------");
-        println!("{}", lyrics);
+        println!("{lyrics}");
         bunt::println!("\n{$green}Lyrics from: {/$}{}", url);
     }
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -7,7 +7,7 @@ pub struct Response {
 }
 
 pub async fn get_lyrics(query: &str) -> (String, String) {
-    let url = format!("https://lyrics.astrid.sh/api/search?q={}", query);
+    let url = format!("https://lyrics.astrid.sh/api/search?q={query}");
     let resp = reqwest::get(&url).await.unwrap();
     //use serde_json to parse the response
     let json: Response = serde_json::from_str(&resp.text().await.unwrap()).unwrap();


### PR DESCRIPTION
This pull request aims to give lints and formatting to the code to make the code easy to maintain and more standardized.

You can have some warns of things and some help to fix them by running `cargo clippy` or making clippy the default checker for rust analyzer.

You can format the code running `cargo fmt`.